### PR TITLE
added captchaVerification with hCaptcha, added global policy and appl…

### DIFF
--- a/config/server.ts
+++ b/config/server.ts
@@ -1,7 +1,9 @@
 export default ({ env }) => ({
-  host: env('HOST', '0.0.0.0'),
-  port: env.int('PORT', 1337),
+  host: env("HOST", "0.0.0.0"),
+  port: env.int("PORT", 1337),
   app: {
-    keys: env.array('APP_KEYS'),
+    keys: env.array("APP_KEYS"),
   },
+  hcaptchaSecret: env("HCAPTCHA_SECRET_KEY"),
+  hcaptchaSiteKey: env("HCAPTCHA_SITE_KEY"),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@strapi/strapi": "5.8.1",
         "better-sqlite3": "11.3.0",
         "fs-extra": "^10.0.0",
+        "hcaptcha": "^0.2.0",
         "mime-types": "^2.1.27",
         "pg": "^8.13.1",
         "react": "^18.0.0",
@@ -10846,6 +10847,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hcaptcha": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/hcaptcha/-/hcaptcha-0.2.0.tgz",
+      "integrity": "sha512-x25z3RoEa9oqfyuQsgk2olc+LCNVDAJaGKUP1qFhpAybB6qjqOf4qB2y1E3LJpXDvM229JWEywc6iWnzWvGjNw=="
     },
     "node_modules/he": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@strapi/strapi": "5.8.1",
     "better-sqlite3": "11.3.0",
     "fs-extra": "^10.0.0",
+    "hcaptcha": "^0.2.0",
     "mime-types": "^2.1.27",
     "pg": "^8.13.1",
     "react": "^18.0.0",

--- a/src/api/contact-form-entry/content-types/contact-form-entry/lifecycles.ts
+++ b/src/api/contact-form-entry/content-types/contact-form-entry/lifecycles.ts
@@ -7,7 +7,7 @@ module.exports = {
     const { result } = event;
     console.log(result);
 
-    console.log("I am coming from lifecycles hook");
+    console.log("I am coming from lifecycles hook contact form");
     // try {
     //   await strapi.plugins["email"].services.email.send({
     //     to: result.email,
@@ -25,16 +25,16 @@ module.exports = {
 
     // maybe need to first check if contact is alrady in the audience before creating ?
 
-    try {
-      resend.contacts.create({
-        email: result.email,
-        firstName: result.name,
-        unsubscribed: false,
-        audienceId: process.env.RESEND_AUDIENCE_ID,
-      });
-    } catch (error) {
-      console.log(error);
-    }
+    // try {
+    //   resend.contacts.create({
+    //     email: result.email,
+    //     firstName: result.name,
+    //     unsubscribed: false,
+    //     audienceId: process.env.RESEND_AUDIENCE_ID,
+    //   });
+    // } catch (error) {
+    //   console.log(error);
+    // }
 
     // send email from resend
     try {

--- a/src/api/contact-form-entry/content-types/contact-form-entry/schema.json
+++ b/src/api/contact-form-entry/content-types/contact-form-entry/schema.json
@@ -21,6 +21,9 @@
     },
     "message": {
       "type": "text"
+    },
+    "captcha": {
+      "type": "text"
     }
   }
 }

--- a/src/api/contact-form-entry/routes/contact-form-entry.ts
+++ b/src/api/contact-form-entry/routes/contact-form-entry.ts
@@ -2,6 +2,10 @@
  * contact-form-entry router
  */
 
-import { factories } from '@strapi/strapi';
+import { factories } from "@strapi/strapi";
 
-export default factories.createCoreRouter('api::contact-form-entry.contact-form-entry');
+export default factories.createCoreRouter("api::contact-form-entry.contact-form-entry", {
+  config: {
+    create: { policies: ["global::verifyCaptcha"] },
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,19 @@ export default {
    *
    * This gives you an opportunity to extend code.
    */
-  register(/* { strapi }: { strapi: Core.Strapi } */) {},
+  register({ strapi }) {
+    strapi.log.info("In register function.");
+    const extensionService = strapi.plugin("graphql").service("extension");
+
+    // read-single policy for letter
+    extensionService.use({
+      resolversConfig: {
+        "Mutation.createContactFormEntry": {
+          policies: ["global::verifyCaptcha"],
+        },
+      },
+    });
+  },
 
   /**
    * An asynchronous bootstrap function that runs before

--- a/src/policies/verifyCaptcha.ts
+++ b/src/policies/verifyCaptcha.ts
@@ -1,0 +1,51 @@
+/**
+ * verifyCaptcha policy
+ */
+
+const { verify } = require("hcaptcha");
+
+export default async (policyContext, config, { strapi }) => {
+  // Add your own logic here.
+  strapi.log.info("In verifyCaptcha policy.");
+  // most likely token is passed wrong
+
+  const secret = strapi.config.get("server.hcaptchaSecret");
+
+  const token = policyContext.args.data.captcha;
+
+  const { name, message } = policyContext.args.data;
+
+  if (!name || !message) {
+    strapi.log.error("Required fields missing");
+    return false;
+  }
+
+  if (!token) {
+    strapi.log.info("Token not found");
+    return false;
+  }
+
+  try {
+    let { success } = await verify(secret, token);
+
+    if (success) {
+      // Equivalent to sending a HTTP 200 status as a server response
+      strapi.log.info("Verification success: ", success);
+      return true;
+    } else {
+      strapi.log.error("Failed captcha score");
+      return false;
+    }
+  } catch (error) {
+    strapi.log.error(error);
+    return false;
+  }
+
+  // const canDoSomething = true;
+
+  // if (canDoSomething) {
+  //   return true;
+  // }
+
+  return false;
+};

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -486,6 +486,7 @@ export interface ApiContactFormEntryContactFormEntry
     draftAndPublish: false;
   };
   attributes: {
+    captcha: Schema.Attribute.Text;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;


### PR DESCRIPTION
…ied it to the graphql resolver as well as to the rest api endpoint for contact-form-entry. 
Best to use rest for posting, easier.

as a reference, for graphql endpoints need to use register function in strapi to add specific middleware to the resolver. 